### PR TITLE
Updated changes around Module stability related to iOS and Swift.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+- Updated podspec for without the version so it will always point to the latest version. 
+- Updated changes around Module stability related to iOS and Swift.
+
 ## 1.1.2
 - Updated Podspec to use `razorpay-pod ~> 1.1.4`
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin is available on Pub: [https://pub.dev/packages/razorpay_flutter](htt
 Add this to `dependencies` in your app's `pubspec.yml`
 
 ```yaml
-razorpay_flutter: ^1.1.1
+razorpay_flutter: ^1.1.3
 ```
 
 **Note for Android**: Make sure that the minimum API level for your app is 19 or higher.

--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -54,11 +54,12 @@ public class RazorpayDelegate: NSObject, RazorpayPaymentCompletionProtocolWithDa
         
         let key = options["key"] as? String
         
-        let razorpay = Razorpay.initWithKey(key ?? "", andDelegateWithData: self)
+        let razorpay = RazorpayCheckout.initWithKey(key ?? "", andDelegateWithData: self)
         razorpay.setExternalWalletSelectionDelegate(self)
-        
+        var options = options
+        options["integration"] = "flutter"
+        options["FRAMEWORK"] = "flutter"
         razorpay.open(options)
-        
     }
     
     public func resync(result: @escaping FlutterResult) {

--- a/ios/razorpay_flutter.podspec
+++ b/ios/razorpay_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'razorpay_flutter'
-  s.version          = '1.1.1'
+  s.version          = '1.1.3'
   s.summary          = 'Flutter plugin for Razorpay SDK.'
   s.description      = 'Flutter plugin for Razorpay SDK.'
   s.homepage         = 'https://github.com/razorpay/razorpay-flutter'
@@ -13,8 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'razorpay-pod', '~> 1.1.4'
+  s.dependency 'razorpay-pod'
 
   s.ios.deployment_target = '10.0'
-  s.swift_version = '5.0'
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: razorpay_flutter
 description: Flutter plugin for Razorpay SDK. To know more about Razorpay, visit http://razorpay.com.
-version: 1.1.2
+version: 1.1.3
 author: Chintan Acharya <chintan.acharya@razorpay.com>
 homepage: https://github.com/razorpay/razorpay-flutter
 


### PR DESCRIPTION
* I have removed Swift version as now it won't be targeting any specific version like Swift 5.0.
* Updated podspec version to the same as flutter plugin version - 1.1.3
* Updated Readme to the latest version. 

You can also suggest me the missing changes if there is any.