### PR TITLE
Added android:export value for Android 12

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   package="com.razorpay.razorpay_flutter">
     <application>
         <activity
+                android:exported="false"
                 android:name="com.razorpay.CheckoutActivity"
                 android:label="Razorpay Checkout" >
         </activity>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -6,5 +6,10 @@
                 android:name="com.razorpay.CheckoutActivity"
                 android:label="Razorpay Checkout" >
         </activity>
+        <receiver android:name="com.razorpay.RzpTokenReceiver" android:exported="false">
+            <intent-filter>
+                <action android:name="rzp.device_token.share" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>


### PR DESCRIPTION
Fixes #228 
I have overridden the razorpaytoken reciever tag here only but this should be done in the token repository i guess. 
Not sure about it. 

- [x]  Changes are tested and I can deploy my build to playstore without any rejection now.