### PR TITLE
Upgrade Packages

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: razorpay_flutter
 description: Flutter plugin for Razorpay SDK. To know more about Razorpay, visit http://razorpay.com.
-version: 1.3.4
+version: 1.3.5
 homepage: https://github.com/razorpay/razorpay-flutter
 
 environment:
@@ -10,9 +10,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  eventify: ^1.0.0
-  fluttertoast: ^8.0.7
-  package_info_plus: ^1.3.0
+  eventify: ^1.0.1
+  fluttertoast: ^8.2.1
+  package_info_plus: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The Packages like package_info_plus had too old version and has been upgraded same goes for fluttertoast and eventify , which maybe causing issues in flutter 3.10.0