### PR TITLE
Update package info plus dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   eventify: ^1.0.0
   fluttertoast: ^8.0.7
-  package_info_plus: ^1.3.0
+  package_info_plus: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes compilation fails on flutter 3.10 for flutter apps that use this plugin

*List of issues fixed by this PR*

Fixes https://github.com/razorpay/razorpay-flutter/issues/322
Fixes https://github.com/razorpay/razorpay-flutter/issues/319

Maybe fix #319  because now plugin is dependent on `package_info_plus: ^4.0.0`.
