### PR TITLE
fix: allow to await `open()` function

### DIFF
--- a/lib/razorpay_flutter.dart
+++ b/lib/razorpay_flutter.dart
@@ -32,7 +32,7 @@ class Razorpay {
   }
 
   /// Opens Razorpay checkout
-  void open(Map<String, dynamic> options) async {
+  Future<void> open(Map<String, dynamic> options) async {
     Map<String, dynamic> validationResult = _validateOptions(options);
 
     if (!validationResult['success']) {


### PR DESCRIPTION
Fixes #291 

Main motive is to await till the transaction is completed and RazorPay overlay fallsback to previous app screen, so that we can proceed with verification.