### PR TITLE
Fixed data typecasting issue in PaymentFailureResponse/fromMap. Resolves Issue #335

### DIFF
--- a/lib/razorpay_flutter.dart
+++ b/lib/razorpay_flutter.dart
@@ -149,7 +149,7 @@ class PaymentFailureResponse {
     var code = map["code"] as int?;
     var message = map["message"] as String?;
     var responseBody =
-        jsonDecode(map["responseBody"]) as Map<dynamic, dynamic>?;
+        jsonDecode(map["responseBody"].toString()) as Map<dynamic, dynamic>?;
     return new PaymentFailureResponse(code, message, responseBody);
   }
 }

--- a/lib/razorpay_flutter.dart
+++ b/lib/razorpay_flutter.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:eventify/eventify.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'dart:convert';
 import 'dart:io' show Platform;
 
 class Razorpay {
@@ -147,7 +148,8 @@ class PaymentFailureResponse {
   static PaymentFailureResponse fromMap(Map<dynamic, dynamic> map) {
     var code = map["code"] as int?;
     var message = map["message"] as String?;
-    var responseBody = map["responseBody"] as Map<dynamic, dynamic>?;
+    var responseBody =
+        jsonDecode(map["responseBody"]) as Map<dynamic, dynamic>?;
     return new PaymentFailureResponse(code, message, responseBody);
   }
 }


### PR DESCRIPTION
#335 `type 'String' is not a subtype of type 'Map<dynamic, dynamic>?' in type cast`

The issue arose because `map[responseBody]` had a runtimeType of `String` and it was being casted to a `Map`.

The fix: using `jsonDecode()` method of `dart:convert` I converted the string to a Map
