### PR TITLE
Fixed: missing init of `responseBody` in `PaymentFailureResponse.from` method

### DIFF
--- a/lib/razorpay_flutter.dart
+++ b/lib/razorpay_flutter.dart
@@ -162,7 +162,7 @@ class PaymentFailureResponse {
   static PaymentFailureResponse fromMap(Map<dynamic, dynamic> map) {
     var code = map["code"] as int?;
     var message = map["message"] as String?;
-    var responseBody;
+    var responseBody = map['responseBody'] as Map<dynamic, dynamic>?;
 
     if (responseBody is Map<dynamic, dynamic>) {
       return new PaymentFailureResponse(code, message, responseBody);


### PR DESCRIPTION
Fixed: missing init of `responseBody` in `PaymentFailureResponse.from` method

```dart
var responseBody;
```

to

```dart
var responseBody = map['responseBody'] as Map<dynamic, dynamic>?;
```