### PR TITLE
Fix view controller presentation by using displayController parameter

### DIFF
--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -13,7 +13,17 @@ public class RazorpayDelegate: NSObject, RazorpayPaymentCompletionProtocolWithDa
     static let TLS_ERROR = 3
     static let INCOMPATIBLE_PLUGIN = 3
     static let UNKNOWN_ERROR = 100
-    
+
+    private static func presentedViewControllerFromRoot() -> UIViewController? {
+        guard let rootVC = UIApplication.shared.windows.filter({ $0.isKeyWindow }).first?.rootViewController,
+              !(rootVC is UINavigationController),
+              let presented = rootVC.presentedViewController else {
+            return nil
+        }
+
+        return presented
+    }
+
     public func onExternalWalletSelected(_ walletName: String, withPaymentData paymentData: [AnyHashable : Any]?) {
         var response = [String:Any]()
         response["type"] = RazorpayDelegate.CODE_PAYMENT_EXTERNAL_WALLET
@@ -59,6 +69,10 @@ public class RazorpayDelegate: NSObject, RazorpayPaymentCompletionProtocolWithDa
         var options = options
         options["integration"] = "flutter"
         options["FRAMEWORK"] = "flutter"
+        if let presentedVC = RazorpayDelegate.presentedViewControllerFromRoot() {
+            razorpay.open(options, displayController: presentedVC)
+            return
+        }
         razorpay.open(options)
     }
     


### PR DESCRIPTION
Fixes #461

Problem:
The Flutter plugin was calling razorpay.open(options) without the displayController parameter, forcing the native Razorpay SDK to use the root view controller for presentation. This fails when the root VC has already presented another view controller, causing the error: "Attempt to present on <UIViewController> which is already presenting"

This occurs in any scenario where modal presentations exist in the view hierarchy (e.g., mixed React Native + Flutter projects, or apps with complex navigation patterns).

Solution:
The native Razorpay iOS SDK (razorpay-pod) supports an optional displayController parameter in its open method to specify which view controller should present the payment interface. This fix leverages that capability:

- Added presentedViewControllerFromRoot() to find the topmost presented view controller in the hierarchy
- Modified razorpay.open() call to pass this controller via displayController parameter when available
- Falls back to original call without displayController if no presented VC exists

This properly utilizes the native SDK's intended flexibility and fixes presentation failures in complex view hierarchies.
