### PR TITLE
Feat/checkout analytics event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@ build/
 
 **/.idea/
 *.iml
+
+# iOS
+**/ios/.symlinks/
+**/ios/Pods/Manifest.lock
+**/ios/Pods/Pods.xcodeproj/xcuserdata/
+**/ios/Pods/Target Support Files/*/ResourceBundle-*
+**/ios/Pods/Target Support Files/razorpay-core-pod/
+**/ios/Pods/**/Resources/
+**/ios/Pods/razorpay-core-pod/
+**/ios/Pods/razorpay-pod/Pod/RazorpayStandard.xcframework/
+
+# Android
+**/.gradle/
+**/android/.gradle/

--- a/android/src/main/java/com/razorpay/razorpay_flutter/RazorpayDelegate.java
+++ b/android/src/main/java/com/razorpay/razorpay_flutter/RazorpayDelegate.java
@@ -2,10 +2,13 @@ package com.razorpay.razorpay_flutter;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import com.razorpay.Checkout;
 import com.razorpay.CheckoutActivity;
+import com.razorpay.EventCallback;
 import com.razorpay.ExternalWalletListener;
 import com.razorpay.PaymentData;
 import com.razorpay.PaymentResultWithDataListener;
@@ -14,14 +17,17 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
+import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
 
-public class RazorpayDelegate implements ActivityResultListener, ExternalWalletListener, PaymentResultWithDataListener {
+public class RazorpayDelegate implements ActivityResultListener, ExternalWalletListener, PaymentResultWithDataListener, EventCallback {
 
     private final Activity activity;
     private Result pendingResult;
@@ -39,7 +45,11 @@ public class RazorpayDelegate implements ActivityResultListener, ExternalWalletL
     private static final int TLS_ERROR = 3;
     private static final int INCOMPATIBLE_PLUGIN = 3;
     private static final int UNKNOWN_ERROR = 100;
+    private static final String TAG = "RazorpayFlutter";
+
     private String packageName;
+    private EventChannel.EventSink merchantEventSink;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
 
     public RazorpayDelegate(Activity activity) {
         this.activity = activity;
@@ -49,9 +59,29 @@ public class RazorpayDelegate implements ActivityResultListener, ExternalWalletL
         this.packageName = packageName;
     }
 
-    void openCheckout(Map<String, Object> arguments, Result result) {
+    void setMerchantEventSink(EventChannel.EventSink sink) {
+        this.merchantEventSink = sink;
+    }
 
-        this.pendingResult = result;
+    void subscribeToAnalyticsEvents(List<String> events, Result result) {
+        try {
+            Checkout checkout = Checkout.getInstance(activity);
+            checkout.setEventCallback(this);
+            if (events != null && !events.isEmpty()) {
+                Method setSubscribed = Checkout.class.getDeclaredMethod("setSubscribedAnalyticsEvents", ArrayList.class);
+                setSubscribed.setAccessible(true);
+                setSubscribed.invoke(checkout, new ArrayList<>(events));
+              }
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to subscribe to analytics events: " + e.getMessage());
+        }
+        if (result != null) {
+            result.success(null);
+        }
+    }
+
+    void openCheckout(Map<String, Object> arguments, Result result) {
+         this.pendingResult = result;
         JSONObject options = new JSONObject(arguments);
         if (activity.getPackageName().equalsIgnoreCase(packageName)){
             Intent intent = new Intent(activity, CheckoutActivity.class);
@@ -59,8 +89,18 @@ public class RazorpayDelegate implements ActivityResultListener, ExternalWalletL
             intent.putExtra("FRAMEWORK", "flutter");
             activity.startActivityForResult(intent, Checkout.RZP_REQUEST_CODE);
         }
+     }
 
-
+    @Override
+    public void onEvent(String payloadJson) {
+        if (merchantEventSink == null) {
+            return;
+        }
+        mainHandler.post(() -> {
+            if (merchantEventSink != null) {
+                merchantEventSink.success(payloadJson);
+            }
+        });
     }
 
     private void sendReply(Map<String, Object> data) {

--- a/android/src/main/java/com/razorpay/razorpay_flutter/RazorpayFlutterPlugin.java
+++ b/android/src/main/java/com/razorpay/razorpay_flutter/RazorpayFlutterPlugin.java
@@ -8,14 +8,17 @@ import org.json.JSONException;
 
 import java.util.Map;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-//import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /**
  * RazorpayFlutterPlugin
@@ -24,24 +27,36 @@ public class RazorpayFlutterPlugin implements FlutterPlugin, MethodCallHandler, 
 
     private RazorpayDelegate razorpayDelegate;
     private ActivityPluginBinding pluginBinding;
-    private static String CHANNEL_NAME = "razorpay_flutter";
+    private static final String CHANNEL_NAME = "razorpay_flutter";
+    private static final String MERCHANT_EVENT_CHANNEL_NAME = "razorpay_flutter/merchant_events";
 
+    private EventChannel.EventSink merchantEventSink;
 
     public RazorpayFlutterPlugin() {
     }
 
-    /**
-     * Plugin registration for Flutter version < 1.12
-     */
-//    public static void registerWith(Registrar registrar) {
-//        final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
-//        channel.setMethodCallHandler(new RazorpayFlutterPlugin(registrar));
-//    }
-
     @Override
     public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-        final MethodChannel channel = new MethodChannel(binding.getBinaryMessenger(), CHANNEL_NAME);
+        MethodChannel channel = new MethodChannel(binding.getBinaryMessenger(), CHANNEL_NAME);
         channel.setMethodCallHandler(this);
+        EventChannel merchantEventChannel = new EventChannel(binding.getBinaryMessenger(), MERCHANT_EVENT_CHANNEL_NAME);
+        merchantEventChannel.setStreamHandler(new EventChannel.StreamHandler() {
+            @Override
+            public void onListen(Object arguments, EventChannel.EventSink events) {
+                merchantEventSink = events;
+                if (razorpayDelegate != null) {
+                    razorpayDelegate.setMerchantEventSink(merchantEventSink);
+                }
+            }
+
+            @Override
+            public void onCancel(Object arguments) {
+                merchantEventSink = null;
+                if (razorpayDelegate != null) {
+                    razorpayDelegate.setMerchantEventSink(null);
+                }
+            }
+        });
     }
 
     @Override
@@ -65,18 +80,22 @@ public class RazorpayFlutterPlugin implements FlutterPlugin, MethodCallHandler, 
 
 
         switch (call.method) {
-
             case "open":
                 razorpayDelegate.openCheckout((Map<String, Object>) call.arguments, result);
                 break;
-
             case "resync":
                 razorpayDelegate.resync(result);
                 break;
-
+            case "subscribeToAnalyticsEvents":
+                @SuppressWarnings("unchecked")
+                Map<String, Object> args = call.arguments != null ? (Map<String, Object>) call.arguments : null;
+                List<String> events = args != null && args.containsKey("events")
+                    ? (List<String>) args.get("events")
+                    : new ArrayList<>();
+                razorpayDelegate.subscribeToAnalyticsEvents(events, result);
+                break;
             default:
                 result.notImplemented();
-
         }
 
     }
@@ -86,6 +105,9 @@ public class RazorpayFlutterPlugin implements FlutterPlugin, MethodCallHandler, 
         this.razorpayDelegate = new RazorpayDelegate(binding.getActivity());
         this.pluginBinding = binding;
         razorpayDelegate.setPackageName(binding.getActivity().getPackageName());
+        if (merchantEventSink != null) {
+            razorpayDelegate.setMerchantEventSink(merchantEventSink);
+        }
         binding.addActivityResultListener(razorpayDelegate);
     }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,6 +50,38 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   int _counter = 0;
+  late Razorpay _razorpay;
+  final List<String> _merchantEvents = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _razorpay = Razorpay();
+    // Subscribe to checkout analytics events before opening checkout
+    _razorpay.subscribeToAnalyticsEvents(
+      ['payment.*', 'checkout.initiate', 'checkout.close'],
+      (String payloadJson) {
+        debugPrint('[Merchant Event] $payloadJson');
+        if (mounted) {
+          setState(() {
+            _merchantEvents.add(payloadJson);
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Event #${_merchantEvents.length}: ${payloadJson.length > 40 ? '${payloadJson.substring(0, 40)}...' : payloadJson}'),
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _razorpay.clear();
+    super.dispose();
+  }
 
   void _incrementCounter() {
     setState(() {
@@ -76,51 +108,78 @@ class _MyHomePageState extends State<MyHomePage> {
         // the App.build method, and use it to set our appbar title.
         title: Text(widget.title),
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Invoke "debug painting" (press "p" in the console, choose the
-          // "Toggle Debug Paint" action from the Flutter Inspector in Android
-          // Studio, or the "Toggle Debug Paint" command in Visual Studio Code)
-          // to see the wireframe for each widget.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'Pay with Razorpay',
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: ElevatedButton(
+              onPressed: () {
+                var options = {
+                  'key': 'rzp_live_ILgsfZCZoFIKMb',
+                  'amount': 100,
+                  'name': 'Acme Corp.',
+                  'description': 'Fine T-Shirt',
+                  'retry': {'enabled': true, 'max_count': 1},
+                  'send_sms_hash': true,
+                  'prefill': {'contact': '8888888888', 'email': 'test@razorpay.com'},
+                  'external': {'wallets': ['paytm']},
+                };
+                _razorpay.on(Razorpay.EVENT_PAYMENT_ERROR, handlePaymentErrorResponse);
+                _razorpay.on(Razorpay.EVENT_PAYMENT_SUCCESS, handlePaymentSuccessResponse);
+                _razorpay.on(Razorpay.EVENT_EXTERNAL_WALLET, handleExternalWalletSelected);
+                _razorpay.open(options);
+              },
+              child: const Text('Pay with Razorpay'),
             ),
-            ElevatedButton(onPressed: (){
-                  Razorpay razorpay = Razorpay();
-                  var options = {
-                    'key': 'rzp_live_ILgsfZCZoFIKMb',
-                    'amount': 100,
-                    'name': 'Acme Corp.',
-                    'description': 'Fine T-Shirt',
-                    'retry': {'enabled': true, 'max_count': 1},
-                    'send_sms_hash': true,
-                    'prefill': {'contact': '8888888888', 'email': 'test@razorpay.com'},
-                    'external': {
-                      'wallets': ['paytm']
-                    }
-                  };
-                  razorpay.on(Razorpay.EVENT_PAYMENT_ERROR, handlePaymentErrorResponse);
-                  razorpay.on(Razorpay.EVENT_PAYMENT_SUCCESS, handlePaymentSuccessResponse);
-                  razorpay.on(Razorpay.EVENT_EXTERNAL_WALLET, handleExternalWalletSelected);
-                  razorpay.open(options);
-                },
-                child: const Text("Pay with Razorpay")),
-          ],
-        ),
+          ),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16.0),
+            child: Text(
+              'Events passed to Flutter (from native):',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+            ),
+          ),
+          Expanded(
+            child: _merchantEvents.isEmpty
+                ? const Center(
+                    child: Text(
+                      'No events yet. Tap "Pay with Razorpay" and use checkout to see events.',
+                      textAlign: TextAlign.center,
+                    ),
+                  )
+                : ListView.builder(
+                    padding: const EdgeInsets.all(16.0),
+                    itemCount: _merchantEvents.length,
+                    itemBuilder: (context, index) {
+                      final event = _merchantEvents[index];
+                      return Card(
+                        margin: const EdgeInsets.only(bottom: 8),
+                        child: Padding(
+                          padding: const EdgeInsets.all(12.0),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Event ${index + 1}',
+                                style: const TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 12,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              SelectableText(
+                                event,
+                                style: const TextStyle(fontSize: 11, fontFamily: 'monospace'),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: _incrementCounter,

--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -1,7 +1,9 @@
 import Flutter
 import Razorpay
+import RazorpayCore
+import UIKit
 
-public class RazorpayDelegate: NSObject, RazorpayPaymentCompletionProtocolWithData, ExternalWalletSelectionProtocol {
+public class RazorpayDelegate: NSObject, RazorpayPaymentCompletionProtocolWithData, ExternalWalletSelectionProtocol, RazorpayEventCallback {
     
     static let CODE_PAYMENT_SUCCESS = 0
     static let CODE_PAYMENT_ERROR = 1
@@ -26,7 +28,25 @@ public class RazorpayDelegate: NSObject, RazorpayPaymentCompletionProtocolWithDa
     }
     
     private var pendingResult: FlutterResult!
-    
+    private var subscribedAnalyticsEvents: [String]?
+    var merchantEventSink: FlutterEventSink?
+
+    private let logTag = "RazorpayFlutter"
+
+    public func subscribeToAnalyticsEvents(events: [String]) {
+        subscribedAnalyticsEvents = events
+    }
+
+    public func onEvent(_ payloadJson: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, let sink = self.merchantEventSink else {
+                print("[RazorpayFlutter] Analytics event received but Flutter listener is not connected")
+                return
+            }
+            sink(payloadJson)
+        }
+    }
+
     public func onPaymentError(_ code: Int32, description message: String, andData data: [AnyHashable : Any]?) {
         var response = [String:Any]()
         response["type"] = RazorpayDelegate.CODE_PAYMENT_ERROR
@@ -48,18 +68,22 @@ public class RazorpayDelegate: NSObject, RazorpayPaymentCompletionProtocolWithDa
         pendingResult(response as NSDictionary)
     }
     
-    public func open(options: Dictionary<String, Any>, result: @escaping FlutterResult) {
-        
+    public func open(options: Dictionary<String, Any>, result: @escaping FlutterResult, from viewController: UIViewController?) {
         self.pendingResult = result
-        
         let key = options["key"] as? String
-        
         let razorpay = RazorpayCheckout.initWithKey(key ?? "", andDelegateWithData: self)
         razorpay.setExternalWalletSelectionDelegate(self)
+        if let events = subscribedAnalyticsEvents, !events.isEmpty {
+            razorpay.subscribeToAnalyticsEvents(events, callback: self)
+        }
         var options = options
         options["integration"] = "flutter"
         options["FRAMEWORK"] = "flutter"
-        razorpay.open(options)
+        if let vc = viewController {
+            razorpay.open(options, displayController: vc)
+        } else {
+            razorpay.open(options)
+        }
     }
     
     public func resync(result: @escaping FlutterResult) {

--- a/ios/Classes/SwiftRazorpayFlutterPlugin.swift
+++ b/ios/Classes/SwiftRazorpayFlutterPlugin.swift
@@ -1,29 +1,65 @@
 import Flutter
 import Razorpay
+import UIKit
 
 public class SwiftRazorpayFlutterPlugin: NSObject, FlutterPlugin {
-    
+
     private var razorpayDelegate = RazorpayDelegate()
-    private static var CHANNEL_NAME = "razorpay_flutter";
-    
+    private static let CHANNEL_NAME = "razorpay_flutter"
+    private static let MERCHANT_EVENT_CHANNEL_NAME = "razorpay_flutter/merchant_events"
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: CHANNEL_NAME, binaryMessenger: registrar.messenger())
         let instance = SwiftRazorpayFlutterPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
+
+        let merchantEventChannel = FlutterEventChannel(name: MERCHANT_EVENT_CHANNEL_NAME, binaryMessenger: registrar.messenger())
+        merchantEventChannel.setStreamHandler(instance)
+    }
+
+    /// Returns the root view controller so the SDK can present checkout. Prefers scene-based API (iOS 13+).
+    private static func rootViewController() -> UIViewController? {
+        if #available(iOS 13.0, *) {
+            for scene in UIApplication.shared.connectedScenes {
+                guard let windowScene = scene as? UIWindowScene else { continue }
+                if let vc = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController {
+                    return vc
+                }
+                if let vc = windowScene.windows.first?.rootViewController {
+                    return vc
+                }
+            }
+        }
+        return UIApplication.shared.keyWindow?.rootViewController
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "open":
             let options = call.arguments as! Dictionary<String, Any>
-            razorpayDelegate.open(options: options, result: result);
-            break;
+            let viewController = Self.rootViewController()
+            razorpayDelegate.open(options: options, result: result, from: viewController)
         case "resync":
             razorpayDelegate.resync(result: result)
-            break
+        case "subscribeToAnalyticsEvents":
+            let args = call.arguments as? [String: Any]
+            let events = (args?["events"] as? [String]) ?? []
+            razorpayDelegate.subscribeToAnalyticsEvents(events: events)
+            result(nil)
         default:
-            print("no method")
+            result(FlutterMethodNotImplemented)
         }
     }
-    
+}
+
+extension SwiftRazorpayFlutterPlugin: FlutterStreamHandler {
+    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        razorpayDelegate.merchantEventSink = events
+        return nil
+    }
+
+    public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        razorpayDelegate.merchantEventSink = nil
+        return nil
+    }
 }

--- a/lib/razorpay_flutter.dart
+++ b/lib/razorpay_flutter.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:eventify/eventify.dart';
 
@@ -20,13 +22,42 @@ class Razorpay {
   static const INCOMPATIBLE_PLUGIN = 4;
   static const UNKNOWN_ERROR = 100;
 
-  static const MethodChannel _channel = const MethodChannel('razorpay_flutter');
+  static const MethodChannel _channel = MethodChannel('razorpay_flutter');
+  static const EventChannel _merchantEventChannel =
+      EventChannel('razorpay_flutter/merchant_events');
 
   // EventEmitter instance used for communication
   late EventEmitter _eventEmitter;
 
+  List<String>? _subscribedAnalyticsEvents;
+  void Function(String payloadJson)? _onMerchantEvent;
+  StreamSubscription<dynamic>? _merchantEventSubscription;
+
   Razorpay() {
-    _eventEmitter = new EventEmitter();
+    _eventEmitter = EventEmitter();
+  }
+
+  /// Subscribes to checkout analytics events. Call before [open] to receive events.
+  /// [events] e.g. ['payment.*', 'checkout.initiate', 'checkout.close'].
+  /// [onEvent] is invoked with raw JSON string for each matching event.
+  void subscribeToAnalyticsEvents(
+      List<String> events, void Function(String payloadJson) onEvent) {
+    _subscribedAnalyticsEvents = List.from(events);
+    _onMerchantEvent = onEvent;
+    _channel.invokeMethod(
+        'subscribeToAnalyticsEvents', <String, dynamic>{'events': events});
+    _merchantEventSubscription?.cancel();
+    _merchantEventSubscription =
+        _merchantEventChannel.receiveBroadcastStream().listen(
+      (dynamic payload) {
+        if (_onMerchantEvent != null && payload is String) {
+          _onMerchantEvent!(payload);
+        }
+      },
+      onError: (dynamic error) {
+        debugPrint('[RazorpayFlutter] merchant event stream error: $error');
+      },
+    );
   }
 
   /// Opens Razorpay checkout
@@ -91,6 +122,10 @@ class Razorpay {
 
   /// Clears all event listeners
   void clear() {
+    _merchantEventSubscription?.cancel();
+    _merchantEventSubscription = null;
+    _onMerchantEvent = null;
+    _subscribedAnalyticsEvents = null;
     _eventEmitter.clear();
   }
 
@@ -121,7 +156,8 @@ class PaymentSuccessResponse {
   String? signature;
   Map<dynamic, dynamic>? data;
 
-  PaymentSuccessResponse(this.paymentId, this.orderId, this.signature, this.data);
+  PaymentSuccessResponse(
+      this.paymentId, this.orderId, this.signature, this.data);
 
   static PaymentSuccessResponse fromMap(Map<dynamic, dynamic> map) {
     String? paymentId = map["razorpay_payment_id"];


### PR DESCRIPTION

Features:
- Add subscribeToAnalyticsEvents() API for real-time checkout events
- Implement EventChannel streaming on Android & iOS
- Fix iOS 13+ deprecated keyWindow with modern Scene API
- Add rootViewController() helper for multi-window support

Changes:
- Android: EventCallback interface, analytics subscription method
- iOS: RazorpayEventCallback protocol, ViewController parameter
- Flutter: EventChannel-based streaming with proper cleanup
- Example: ListView UI demonstrating event subscription

Improvements:
- Fix iOS 13+ deprecation warnings
- Fix iPad split-view checkout presentation
- Add multi-window app support
- Clean up verbose production logs







