### PR TITLE
Fix: SDK crash on FPX transaction cancellation (ISS-1872468)

### DIFF
--- a/lib/razorpay_flutter.dart
+++ b/lib/razorpay_flutter.dart
@@ -162,14 +162,13 @@ class PaymentFailureResponse {
   static PaymentFailureResponse fromMap(Map<dynamic, dynamic> map) {
     var code = map["code"] as int?;
     var message = map["message"] as String?;
-    var responseBody;
+    var responseBody = map["responseBody"];
 
     if (responseBody is Map<dynamic, dynamic>) {
       return new PaymentFailureResponse(code, message, responseBody);
-    } else{
-      Map<dynamic, dynamic> errorMap = new Map<dynamic, dynamic>();
-      errorMap["reason"] = responseBody;
-      return new PaymentFailureResponse(code, message, responseBody);
+    } else {
+      Map<dynamic, dynamic> errorMap = {"reason": responseBody};
+      return new PaymentFailureResponse(code, message, errorMap);
     }
   }
 }


### PR DESCRIPTION
## Summary

- **Fixes** `PaymentFailureResponse.fromMap` crash when Android native layer returns a String `responseBody` instead of a Map (e.g., FPX cancellation on Curlec)
- The `responseBody` variable was declared but **never assigned from the map**, causing silent data loss on current version and a type cast crash (`type 'String' is not a subtype of type 'Map<dynamic, dynamic>?'`) on v1.4.0/v1.4.3
- Non-Map `responseBody` values are now wrapped in `{"reason": responseBody}` to satisfy the type contract

## Root Cause

When FPX transactions are cancelled, the bank returns a plain-text error. In `RazorpayDelegate.java`, the `onPaymentError` catch block puts this raw String into `data["responseBody"]`:

```java
catch (JSONException e) {
    data.put("message", message);
    data.put("responseBody", message);  // ← String, not Map
}
```

The Dart `PaymentFailureResponse.fromMap` never read this value from the map (`var responseBody;` with no assignment), and passed the untyped value directly to the constructor.

## Changes

**`lib/razorpay_flutter.dart`** — `PaymentFailureResponse.fromMap()`:
1. Read `responseBody` from the map: `var responseBody = map["responseBody"];`
2. Wrap non-Map values in `{"reason": responseBody}` instead of passing raw value
3. Pass `errorMap` (not raw `responseBody`) in the else branch