### PR TITLE
[ISS-1879891]Fix/payment failure response type cast v1.4.3

### DIFF
--- a/android/src/main/java/com/razorpay/razorpay_flutter/RazorpayDelegate.java
+++ b/android/src/main/java/com/razorpay/razorpay_flutter/RazorpayDelegate.java
@@ -165,7 +165,9 @@ public class RazorpayDelegate implements ActivityResultListener, ExternalWalletL
             data.put("responseBody", resp);
         }catch (JSONException e){
             data.put("message", message);
-            data.put("responseBody", message);
+            Map<String, Object> resp = new HashMap<>();
+            resp.put("description", message);
+            data.put("responseBody", resp);
         }
 
         reply.put("data", data);

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace "com.razorpay.razorpay_flutter.example"
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,45 +1,33 @@
 PODS:
   - Flutter (1.0.0)
-  - fluttertoast (0.0.2):
-    - Flutter
-    - Toast
-  - package_info_plus (0.4.5):
-    - Flutter
-  - razorpay-pod (1.3.0)
+  - razorpay-core-pod (1.0.6)
+  - razorpay-pod (1.5.3):
+    - razorpay-core-pod (= 1.0.6)
   - razorpay_flutter (1.1.10):
     - Flutter
     - razorpay-pod
-  - Toast (4.0.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - fluttertoast (from `.symlinks/plugins/fluttertoast/ios`)
-  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - razorpay_flutter (from `.symlinks/plugins/razorpay_flutter/ios`)
 
 SPEC REPOS:
   trunk:
+    - razorpay-core-pod
     - razorpay-pod
-    - Toast
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  fluttertoast:
-    :path: ".symlinks/plugins/fluttertoast/ios"
-  package_info_plus:
-    :path: ".symlinks/plugins/package_info_plus/ios"
   razorpay_flutter:
     :path: ".symlinks/plugins/razorpay_flutter/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  fluttertoast: 74526702fea2c060ea55dde75895b7e1bde1c86b
-  package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
-  razorpay-pod: ebc78907f756ace307e3fa4270ff684ebb9e291b
-  razorpay_flutter: 84b3bfd206ae9c9c2a9ba585524a1b3d8102b6c1
-  Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  razorpay-core-pod: 6da5fb4ed280279d665507fdb50e213d793a5fe2
+  razorpay-pod: 4385cf844aa29389313b741e20c72fe668970d49
+  razorpay_flutter: 0e98e4fcaae27ad50e011d85f66d85e0a008754a
 
-PODFILE CHECKSUM: ef19549a9bc3046e7bb7d2fab4d021637c0c58a3
+PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.16.2

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -8,228 +8,144 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // Try running your application with "flutter run". You'll see the
-        // application has a blue toolbar. Then, without quitting the app, try
-        // changing the primarySwatch below to Colors.green and then invoke
-        // "hot reload" (press "r" in the console where you ran "flutter run",
-        // or simply save your changes to "hot reload" in a Flutter IDE).
-        // Notice that the counter didn't reset back to zero; the application
-        // is not restarted.
-        primarySwatch: Colors.blue,
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      title: 'Razorpay FPX Test',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const MyHomePage(),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
+  const MyHomePage({super.key});
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
   late Razorpay _razorpay;
-  final List<String> _merchantEvents = [];
+  final _keyController = TextEditingController();
+  final List<String> _logs = [];
 
   @override
   void initState() {
     super.initState();
     _razorpay = Razorpay();
-    // Subscribe to checkout analytics events before opening checkout
-    _razorpay.subscribeToAnalyticsEvents(
-      ['payment.*', 'checkout.initiate', 'checkout.close'],
-      (String payloadJson) {
-        debugPrint('[Merchant Event] $payloadJson');
-        if (mounted) {
-          setState(() {
-            _merchantEvents.add(payloadJson);
-          });
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text('Event #${_merchantEvents.length}: ${payloadJson.length > 40 ? '${payloadJson.substring(0, 40)}...' : payloadJson}'),
-              duration: const Duration(seconds: 2),
-            ),
-          );
-        }
-      },
-    );
+    _razorpay.on(Razorpay.EVENT_PAYMENT_SUCCESS, _handleSuccess);
+    _razorpay.on(Razorpay.EVENT_PAYMENT_ERROR, _handleError);
+    _razorpay.on(Razorpay.EVENT_EXTERNAL_WALLET, _handleExternalWallet);
   }
 
   @override
   void dispose() {
     _razorpay.clear();
+    _keyController.dispose();
     super.dispose();
   }
 
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
+  void _log(String msg) {
+    setState(() => _logs.insert(0, '[${DateTime.now().toIso8601String().substring(11, 19)}] $msg'));
+  }
+
+  void _handleSuccess(PaymentSuccessResponse response) {
+    _log('SUCCESS — payment_id: ${response.paymentId}');
+    _showDialog('Payment Success', 'Payment ID: ${response.paymentId}');
+  }
+
+  void _handleError(PaymentFailureResponse response) {
+    _log('ERROR — code: ${response.code}, msg: ${response.message}, error: ${response.error}');
+    _showDialog('Payment Failed', 'Code: ${response.code}\nMessage: ${response.message}\nError: ${response.error}');
+  }
+
+  void _handleExternalWallet(ExternalWalletResponse response) {
+    _log('EXTERNAL WALLET — ${response.walletName}');
+    _showDialog('External Wallet', '${response.walletName}');
+  }
+
+  void _openCheckout() {
+    final key = _keyController.text.trim();
+    if (key.isEmpty) {
+      _showDialog('Error', 'Please enter a Razorpay key first.');
+      return;
+    }
+    _log('Opening checkout with key: ${key.substring(0, key.length.clamp(0, 12))}...');
+    var options = {
+      'key': key,
+      'amount': 100,
+      'name': 'FPX Crash Test',
+      'description': 'Testing FPX cancellation crash',
+      'send_sms_hash': true,
+      'prefill': {'contact': '8888888888', 'email': 'test@razorpay.com'},
+    };
+    try {
+      _razorpay.open(options);
+    } catch (e) {
+      _log('EXCEPTION: $e');
+    }
+  }
+
+  void _showDialog(String title, String message) {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: Text(title),
+        content: SingleChildScrollView(child: Text(message)),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('OK')),
+        ],
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
     return Scaffold(
-      appBar: AppBar(
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
-      ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: ElevatedButton(
-              onPressed: () {
-                var options = {
-                  'key': 'rzp_live_ILgsfZCZoFIKMb',
-                  'amount': 100,
-                  'name': 'Acme Corp.',
-                  'description': 'Fine T-Shirt',
-                  'retry': {'enabled': true, 'max_count': 1},
-                  'send_sms_hash': true,
-                  'prefill': {'contact': '8888888888', 'email': 'test@razorpay.com'},
-                  'external': {'wallets': ['paytm']},
-                };
-                _razorpay.on(Razorpay.EVENT_PAYMENT_ERROR, handlePaymentErrorResponse);
-                _razorpay.on(Razorpay.EVENT_PAYMENT_SUCCESS, handlePaymentSuccessResponse);
-                _razorpay.on(Razorpay.EVENT_EXTERNAL_WALLET, handleExternalWalletSelected);
-                _razorpay.open(options);
-              },
-              child: const Text('Pay with Razorpay'),
+      appBar: AppBar(title: const Text('Razorpay FPX Crash Test')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _keyController,
+              decoration: const InputDecoration(
+                labelText: 'Razorpay Key (rzp_test_... or rzp_live_...)',
+                border: OutlineInputBorder(),
+              ),
+              autocorrect: false,
+              enableSuggestions: false,
             ),
-          ),
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16.0),
-            child: Text(
-              'Events passed to Flutter (from native):',
-              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _openCheckout,
+              child: const Text('Open Checkout (test FPX cancellation)'),
             ),
-          ),
-          Expanded(
-            child: _merchantEvents.isEmpty
-                ? const Center(
-                    child: Text(
-                      'No events yet. Tap "Pay with Razorpay" and use checkout to see events.',
-                      textAlign: TextAlign.center,
-                    ),
-                  )
-                : ListView.builder(
-                    padding: const EdgeInsets.all(16.0),
-                    itemCount: _merchantEvents.length,
-                    itemBuilder: (context, index) {
-                      final event = _merchantEvents[index];
-                      return Card(
-                        margin: const EdgeInsets.only(bottom: 8),
+            const SizedBox(height: 16),
+            const Text('Event Log:', style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Expanded(
+              child: _logs.isEmpty
+                  ? const Center(child: Text('No events yet.\nEnter key, tap button, choose FPX, then cancel on the bank page.', textAlign: TextAlign.center))
+                  : ListView.builder(
+                      itemCount: _logs.length,
+                      itemBuilder: (_, i) => Card(
+                        margin: const EdgeInsets.only(bottom: 6),
                         child: Padding(
-                          padding: const EdgeInsets.all(12.0),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                'Event ${index + 1}',
-                                style: const TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  fontSize: 12,
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              SelectableText(
-                                event,
-                                style: const TextStyle(fontSize: 11, fontFamily: 'monospace'),
-                              ),
-                            ],
+                          padding: const EdgeInsets.all(10),
+                          child: SelectableText(
+                            _logs[i],
+                            style: const TextStyle(fontSize: 12, fontFamily: 'monospace'),
                           ),
                         ),
-                      );
-                    },
-                  ),
-          ),
-        ],
+                      ),
+                    ),
+            ),
+          ],
+        ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
-
-  void handlePaymentErrorResponse(PaymentFailureResponse response){
-    /*
-    * PaymentFailureResponse contains three values:
-    * 1. Error Code
-    * 2. Error Description
-    * 3. Metadata
-    * */
-    showAlertDialog(context, "Payment Failed", "Code: ${response.code}\nDescription: ${response.message}\nMetadata:${response.error.toString()}");
-  }
-
-  void handlePaymentSuccessResponse(PaymentSuccessResponse response){
-    /*
-    * Payment Success Response contains three values:
-    * 1. Order ID
-    * 2. Payment ID
-    * 3. Signature
-    * */
-    showAlertDialog(context, "Payment Successful", "Payment ID: ${response.paymentId}");
-  }
-
-  void handleExternalWalletSelected(ExternalWalletResponse response){
-    showAlertDialog(context, "External Wallet Selected", "${response.walletName}");
-  }
-
-  void showAlertDialog(BuildContext context, String title, String message){
-    // set up the buttons
-    Widget continueButton = ElevatedButton(
-      child: const Text("Continue"),
-      onPressed:  () {},
-    );
-    // set up the AlertDialog
-    AlertDialog alert = AlertDialog(
-      title: Text(title),
-      content: Text(message),
-    );
-    // show the dialog
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return alert;
-      },
     );
   }
 }

--- a/lib/razorpay_flutter.dart
+++ b/lib/razorpay_flutter.dart
@@ -179,7 +179,8 @@ class PaymentFailureResponse {
   static PaymentFailureResponse fromMap(Map<dynamic, dynamic> map) {
     var code = map["code"] as int?;
     var message = map["message"] as String?;
-    var responseBody = map["responseBody"] as Map<dynamic, dynamic>?;
+    var rawBody = map["responseBody"];
+    var responseBody = rawBody is Map<dynamic, dynamic> ? rawBody : null;
     return new PaymentFailureResponse(code, message, responseBody);
   }
 }

--- a/test/razorpay_flutter_test.dart
+++ b/test/razorpay_flutter_test.dart
@@ -3,6 +3,64 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:razorpay_flutter/razorpay_flutter.dart';
 
 void main() {
+  // Regression tests for: type 'String' is not a subtype of type 'Map<dynamic, dynamic>?'
+  // When the native layer (Android/iOS) sends a plain-text error string instead of a
+  // structured JSON object (e.g. FPX cancellation, UPI Turbo errors), the hard cast in
+  // PaymentFailureResponse.fromMap() crashes before onPaymentError fires.
+  group("PaymentFailureResponse", () {
+    group("#fromMap", () {
+      test('parses correctly when responseBody is a Map (happy path)', () {
+        final map = {
+          'code': 2,
+          'message': 'Payment cancelled',
+          'responseBody': {
+            'code': 'BAD_REQUEST_ERROR',
+            'description': 'Payment cancelled by user',
+            'source': 'customer',
+            'step': 'payment_authentication',
+            'reason': 'payment_cancelled',
+            'metadata': {'payment_id': 'pay_abc123', 'order_id': 'order_xyz'},
+          }
+        };
+
+        final response = PaymentFailureResponse.fromMap(map);
+
+        expect(response.code, equals(2));
+        expect(response.message, equals('Payment cancelled'));
+        expect(response.error, isA<Map>());
+        expect(response.error!['code'], equals('BAD_REQUEST_ERROR'));
+      });
+
+      test('does not crash when responseBody is a String (FPX/plain-text error path)', () {
+        final map = {
+          'code': 2,
+          'message': 'Post payment parsing error',
+          'responseBody': 'Post payment parsing error',
+        };
+
+        expect(() => PaymentFailureResponse.fromMap(map), returnsNormally);
+
+        final response = PaymentFailureResponse.fromMap(map);
+        expect(response.code, equals(2));
+        expect(response.message, equals('Post payment parsing error'));
+        expect(response.error, isNull);
+      });
+
+      test('handles absent responseBody gracefully (INVALID_OPTIONS path)', () {
+        final map = {
+          'code': 1,
+          'message': 'Key is required.',
+        };
+
+        final response = PaymentFailureResponse.fromMap(map);
+
+        expect(response.code, equals(1));
+        expect(response.message, equals('Key is required.'));
+        expect(response.error, isNull);
+      });
+    });
+  });
+
   group("$Razorpay", () {
     const MethodChannel channel = MethodChannel("razorpay_flutter");
 


### PR DESCRIPTION
## Root Cause
When the bank returns a plain-text response (not JSON), the Android catch block sends `responseBody` as a raw `String`. The Dart layer hard-casts it to `Map<dynamic, dynamic>?` and crashes.

## Fix
**Android (`RazorpayDelegate.java`)** — wrap plain-text message in a Map in the catch block so `responseBody` is always a Map.

**Dart (`razorpay_flutter.dart`)** — replace hard cast with safe type-check, degrades to `null` instead of crashing.

## Example App
- Added key input field (removed hardcoded key)
- Added real-time event log to surface `onPaymentError`, `onPaymentSuccess`, `onExternalWallet` callbacks on screen
- Upgraded Gradle 7.4 → 8.5, AGP 7.1.2 → 8.1.4, Kotlin 1.6.10 → 1.9.0 to fix Java 21 build incompatibility

## Testing
Verified on device — `onPaymentError` now fires correctly on FPX cancellation. Normal payment failure and success flows unaffected.

## Risk
Zero impact on existing flows. Android change is isolated to the catch block only. Dart change is identical for all Map inputs.
