### PR TITLE
[ISS-3214060] fix(ios): defer RazorpayCheckout init/open to next run loop 

### DIFF
--- a/ios/Classes/RazorpayDelegate.swift
+++ b/ios/Classes/RazorpayDelegate.swift
@@ -71,18 +71,21 @@ public class RazorpayDelegate: NSObject, RazorpayPaymentCompletionProtocolWithDa
     public func open(options: Dictionary<String, Any>, result: @escaping FlutterResult, from viewController: UIViewController?) {
         self.pendingResult = result
         let key = options["key"] as? String
-        let razorpay = RazorpayCheckout.initWithKey(key ?? "", andDelegateWithData: self)
-        razorpay.setExternalWalletSelectionDelegate(self)
-        if let events = subscribedAnalyticsEvents, !events.isEmpty {
-            razorpay.subscribeToAnalyticsEvents(events, callback: self)
-        }
         var options = options
         options["integration"] = "flutter"
         options["FRAMEWORK"] = "flutter"
-        if let vc = viewController {
-            razorpay.open(options, displayController: vc)
-        } else {
-            razorpay.open(options)
+
+        DispatchQueue.main.async {
+            let razorpay = RazorpayCheckout.initWithKey(key ?? "", andDelegateWithData: self)
+            razorpay.setExternalWalletSelectionDelegate(self)
+            if let events = self.subscribedAnalyticsEvents, !events.isEmpty {
+                razorpay.subscribeToAnalyticsEvents(events, callback: self)
+            }
+            if let vc = viewController {
+                razorpay.open(options, displayController: vc)
+            } else {
+                razorpay.open(options)
+            }
         }
     }
     


### PR DESCRIPTION
### Summary
Fixes an intermittent EXC_BAD_ACCESS crash in RazorpayCheckout.open() reported on some iOS devices, immediately after checkout initialization (### This is standard checkout IMPL log line), while running the exact same app build and payment options that succeed on other devices.

### Fix
Wrap the SDK-touching calls in RazorpayDelegate.open(options:result:from:) in DispatchQueue.main.async. This keeps execution on the main thread (required for UI presentation) but defers it to the next run-loop turn, unwinding the stack back to the run loop before the SDK's metadata resolution runs — removing the additional depth contributed by Flutter's dispatch chain and giving the SDK more headroom against the fixed ~1MB main-thread stack limit