### PR TITLE
Add opt-in rawMap flag to Razorpay.on() for coexistence with razorpay_flutter_customui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.6
+
+- Added opt-in `rawMap` parameter to `Razorpay.on(event, handler, {rawMap})`. When `true`, handlers receive the raw unwrapped `data` map instead of typed response objects, letting merchants share a single handler with `razorpay_flutter_customui`'s `unwrapData` opt-in. Default behavior is unchanged.
+
 ## 1.4.5
 
 - Added null safety guards in `onPaymentError` to handle cases where `PaymentData` is null (e.g., FPX cancellation)

--- a/lib/razorpay_flutter.dart
+++ b/lib/razorpay_flutter.dart
@@ -34,6 +34,12 @@ class Razorpay {
   void Function(String payloadJson)? _onMerchantEvent;
   StreamSubscription<dynamic>? _merchantEventSubscription;
 
+  /// Tracks event registrations that should receive the raw native
+  /// response map instead of the typed response classes. This lets
+  /// merchants share a single handler between razorpay_flutter and
+  /// razorpay_flutter_customui.
+  final Set<String> _rawMapEvents = <String>{};
+
   Razorpay() {
     _eventEmitter = EventEmitter();
   }
@@ -90,30 +96,50 @@ class Razorpay {
     switch (response['type']) {
       case _CODE_PAYMENT_SUCCESS:
         eventName = EVENT_PAYMENT_SUCCESS;
-        payload = PaymentSuccessResponse.fromMap(data!);
+        payload = _rawMapEvents.contains(EVENT_PAYMENT_SUCCESS)
+            ? (data ?? <dynamic, dynamic>{})
+            : PaymentSuccessResponse.fromMap(data!);
         break;
 
       case _CODE_PAYMENT_ERROR:
         eventName = EVENT_PAYMENT_ERROR;
-        payload = PaymentFailureResponse.fromMap(data!);
+        payload = _rawMapEvents.contains(EVENT_PAYMENT_ERROR)
+            ? (data ?? <dynamic, dynamic>{})
+            : PaymentFailureResponse.fromMap(data!);
         break;
 
       case _CODE_PAYMENT_EXTERNAL_WALLET:
         eventName = EVENT_EXTERNAL_WALLET;
-        payload = ExternalWalletResponse.fromMap(data!);
+        payload = _rawMapEvents.contains(EVENT_EXTERNAL_WALLET)
+            ? (data ?? <dynamic, dynamic>{})
+            : ExternalWalletResponse.fromMap(data!);
         break;
 
       default:
         eventName = 'error';
-        payload = PaymentFailureResponse(
-            UNKNOWN_ERROR, 'An unknown error occurred.', null);
+        payload = _rawMapEvents.contains(EVENT_PAYMENT_ERROR)
+            ? (data ?? <dynamic, dynamic>{})
+            : PaymentFailureResponse(
+                UNKNOWN_ERROR, 'An unknown error occurred.', null);
     }
 
     _eventEmitter.emit(eventName, null, payload);
   }
 
-  /// Registers event listeners for payment events
-  void on(String event, Function handler) {
+  /// Registers event listeners for payment events.
+  ///
+  /// By default the handler receives the typed response class
+  /// (e.g. [PaymentSuccessResponse]). Set [rawMap] to `true` to receive the
+  /// raw native response map instead. This is useful when you want to share
+  /// the same handler between `razorpay_flutter` and
+  /// `razorpay_flutter_customui`.
+  void on(String event, Function handler, {bool rawMap = false}) {
+    if (rawMap) {
+      _rawMapEvents.add(event);
+    } else {
+      _rawMapEvents.remove(event);
+    }
+
     EventCallback cb = (event, cont) {
       handler(event.eventData);
     };
@@ -123,6 +149,7 @@ class Razorpay {
 
   /// Clears all event listeners
   void clear() {
+    _rawMapEvents.clear();
     _merchantEventSubscription?.cancel();
     _merchantEventSubscription = null;
     _onMerchantEvent = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: razorpay_flutter
 description: Flutter plugin for Razorpay SDK. To know more about Razorpay, visit http://razorpay.com.
-version: 1.4.5
+version: 1.4.6
 homepage: https://github.com/razorpay/razorpay-flutter
 
 environment:

--- a/test/razorpay_flutter_test.dart
+++ b/test/razorpay_flutter_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:razorpay_flutter/razorpay_flutter.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   // Regression tests for: type 'String' is not a subtype of type 'Map<dynamic, dynamic>?'
   // When the native layer (Android/iOS) sends a plain-text error string instead of a
   // structured JSON object (e.g. FPX cancellation, UPI Turbo errors), the hard cast in
@@ -114,6 +116,88 @@ void main() {
             Razorpay.EVENT_PAYMENT_ERROR, expectAsync1(errorHandler, count: 1));
 
         razorpay.open(options);
+      });
+
+      group('with rawMap: true', () {
+        test('emits raw map for payment success', () async {
+          channel.setMockMethodCallHandler((MethodCall call) async {
+            if (call.method == 'resync') {
+              return null;
+            }
+            return {
+              'type': 0,
+              'data': {
+                'razorpay_payment_id': 'pay_123',
+                'razorpay_order_id': 'order_456',
+              }
+            };
+          });
+
+          razorpay.clear();
+
+          var successHandler = (Map<dynamic, dynamic> response) {
+            expect(response['razorpay_payment_id'], equals('pay_123'));
+            expect(response['razorpay_order_id'], equals('order_456'));
+          };
+
+          razorpay.on(Razorpay.EVENT_PAYMENT_SUCCESS,
+              expectAsync1(successHandler, count: 1),
+              rawMap: true);
+
+          razorpay.open({'key': 'rzp_test_xxx'});
+        });
+
+        test('emits raw map for payment error', () async {
+          channel.setMockMethodCallHandler((MethodCall call) async {
+            if (call.method == 'resync') {
+              return null;
+            }
+            return {
+              'type': 1,
+              'data': {
+                'code': Razorpay.NETWORK_ERROR,
+                'message': 'Network error',
+              }
+            };
+          });
+
+          razorpay.clear();
+
+          var errorHandler = (Map<dynamic, dynamic> response) {
+            expect(response['code'], equals(Razorpay.NETWORK_ERROR));
+            expect(response['message'], equals('Network error'));
+          };
+
+          razorpay.on(Razorpay.EVENT_PAYMENT_ERROR,
+              expectAsync1(errorHandler, count: 1),
+              rawMap: true);
+
+          razorpay.open({'key': 'rzp_test_xxx'});
+        });
+
+        test('emits raw map for external wallet', () async {
+          channel.setMockMethodCallHandler((MethodCall call) async {
+            if (call.method == 'resync') {
+              return null;
+            }
+            return {
+              'type': 2,
+              'data': {'external_wallet': 'paytm'}
+            };
+          });
+
+          razorpay.clear();
+
+          var walletHandler = (Map<dynamic, dynamic> response) {
+            expect(response['external_wallet'], equals('paytm'));
+          };
+
+          razorpay.on(Razorpay.EVENT_EXTERNAL_WALLET,
+              expectAsync1(walletHandler, count: 1),
+              rawMap: true);
+
+          razorpay.open({'key': 'rzp_test_xxx'});
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary
- Adds an opt-in `rawMap` boolean parameter to `Razorpay.on(event, handler, {rawMap})`.
- Default (`false`) is unchanged: handlers keep receiving the existing typed response objects (`PaymentSuccessResponse`, `PaymentFailureResponse`, `ExternalWalletResponse`).
- When `rawMap: true`, the handler instead receives the raw, unwrapped `data` map straight from the native response (e.g. `{razorpay_payment_id: ..., razorpay_order_id: ..., razorpay_signature: ...}`), with no typed wrapper.

## Why
Apps that integrate both `razorpay_flutter` (standard hosted checkout) and `razorpay_flutter_customui` (headless custom UI checkout) side by side want to share a single payment-result handler across both SDKs. `razorpay_flutter_customui` emits `{type, data}` envelopes and now has a matching opt-in (`unwrapData`) that unwraps to the inner `data` map. `rawMap: true` here produces the same flattened map shape, so a shared handler can be written once and reused for both checkouts:

```dart
razorpayStd.on(Razorpay.EVENT_PAYMENT_SUCCESS, sharedHandler, rawMap: true);
razorpayCustomUi.on(customui.Razorpay.EVENT_PAYMENT_SUCCESS, sharedHandler, unwrapData: true);
```

This is purely additive — the default behavior and typed response classes are untouched, so no existing integration is affected.

## Test plan
- [x] `flutter test` — all tests pass, including new tests in `test/razorpay_flutter_test.dart` covering `rawMap: true`/`false` for success, error, and external wallet events
- [x] Verified end-to-end in a combined sample app alongside `razorpay_flutter_customui`'s `unwrapData` flag, confirming both SDKs deliver an identical flattened map shape to a shared handler